### PR TITLE
Switch to R24 to avoid dialyzer regression

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,11 @@
     let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
 
+      erlang = pkgs.erlangR24;
+
       # Specify dependencies
       buildInputs = [
-        pkgs.erlang
+        erlang
         pkgs.gnumake
         pkgs.glibcLocalesUtf8
       ];
@@ -68,7 +70,7 @@
              b=$(basename $f)
               if [ "$b" = mix ]; then continue; fi
               wrapProgram $f \
-                --prefix PATH ":" "${pkgs.lib.makeBinPath [ pkgs.erlang pkgs.coreutils pkgs.curl pkgs.bash ]}"
+                --prefix PATH ":" "${pkgs.lib.makeBinPath [ erlang pkgs.coreutils pkgs.curl pkgs.bash ]}"
             done
             substituteInPlace $out/bin/mix \
                   --replace "/usr/bin/env elixir" "${pkgs.coreutils}/bin/env elixir"


### PR DESCRIPTION
# Why?

See https://github.com/erlang/otp/issues/6935.

Since we power-use dialyzer and plan to extend Uptight.Result.t() with a type parameter too (btw, there needs to be an issue for that), we need to stay on R24 for the time being.

# What?

 - [x] Enumerate all the projects that use `goo`-lang.
 - [x] witchcraft-goo, type_class-goo, cognivore/type_nest, something else?..
 - [x] Merge this PR
 - [x] For each of the enumerated projects, check that flake.nix uses the correct version of the expression